### PR TITLE
chore: allow setting source and destination clusters for replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here's a quick rundown of the commands available:
 ./synch synctable <table_name>
 
 # Replay query history between clusters for benchmarking
-./synch replay <cluster> <start_date> <end_date>
+./synch replay <cluster> <from_clickhouse_url> <to_clickhouse_url> <start_date> <end_date>
 ```
 
 ## Configuration

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -176,7 +176,7 @@ func NewCHConn(url *string) (*sql.DB, error) {
 		return nil, fmt.Errorf("getting clickhouse connection: %v", err)
 	}
 
-	retry(3, time.Second, func() error {
+	err = retry(3, time.Second, func() error {
 		if _, err := db.Exec("SELECT 1"); err != nil {
 			return fmt.Errorf("trying to ping clickhouse: %s", err)
 		}

--- a/replay.go
+++ b/replay.go
@@ -185,6 +185,21 @@ func csvWriter(results <-chan QueryResult, wg *sync.WaitGroup) {
 	defer file.Close()
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
+	if err := writer.Write(
+		[]string{
+			"number",
+			"original_start_time",
+			"original_duration_ms",
+			"replay_start_time",
+			"replay_duration_ms",
+			"delta_ms",
+			"query_errored",
+			"error",
+			"query",
+		}); err != nil {
+		log.Fatalln("error writing record to csv:", err)
+		wg.Done()
+	}
 
 	// Write all the records
 	for r := range results {

--- a/sync.go
+++ b/sync.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func updateTables(ctx context.Context, connEU, connCloud driver.Conn) {
+func updateTables(connEU, connCloud driver.Conn) {
 	for _, table := range tables {
 		if err := updateTable(context.Background(), connEU, connCloud, viper.GetString("CLICKHOUSE_EU_DATABASE"), table, false, true); err != nil {
 			panic(err)


### PR DESCRIPTION
They were hardcoded for EU and CH Cloud.

Now it allows to use any connection string.

