### PR TITLE
feat: add --no-distributed flag to skip Distributed tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Here's a quick rundown of the commands available:
 # Dump database schema to file _without_ kafka or materialized view tables
 ./synch dump-schema --no-kafkas --no-mat-views <clickhouse_url> <file> <database>
 
+# Dump database schema to file _without_ Distributed tables
+./synch dump-schema --no-distributed <clickhouse_url> <file> <database>
+
 # Dump database schema to file _with_ IF NOT EXISTS in CREATE TABLE statements
 ./synch dump-schema --if-not-exists <clickhouse_url> <file> <database>
 

--- a/main.go
+++ b/main.go
@@ -78,11 +78,12 @@ func main() {
 	})
 
 	var (
-		noKafkas     = false
-		noMatViews   = false
-		onlyKafkas   = false
-		onlyMatViews = false
-		ifNotExists  = false
+		noKafkas      = false
+		noMatViews    = false
+		noDistributed = false
+		onlyKafkas    = false
+		onlyMatViews  = false
+		ifNotExists   = false
 	)
 
 	dumpSchemaCmd := &cobra.Command{
@@ -104,14 +105,15 @@ func main() {
 			defer conn.Close()
 
 			opts := Options{
-				DB:           conn,
-				Path:         *file,
-				SpecifiedDB:  *specifiedDB,
-				NoKafkas:     noKafkas,
-				NoMatViews:   noMatViews,
-				OnlyKafkas:   onlyKafkas,
-				OnlyMatViews: onlyMatViews,
-				IfNotExists:  ifNotExists,
+				DB:            conn,
+				Path:          *file,
+				SpecifiedDB:   *specifiedDB,
+				NoKafkas:      noKafkas,
+				NoMatViews:    noMatViews,
+				NoDistributed: noDistributed,
+				OnlyKafkas:    onlyKafkas,
+				OnlyMatViews:  onlyMatViews,
+				IfNotExists:   ifNotExists,
 			}
 
 			err = Write(&opts)
@@ -128,6 +130,7 @@ func main() {
 
 	dumpSchemaCmd.Flags().BoolVar(&noKafkas, "no-kafkas", false, "Don't dump Kafka tables")
 	dumpSchemaCmd.Flags().BoolVar(&noMatViews, "no-mat-views", false, "Don't dump materialized views")
+	dumpSchemaCmd.Flags().BoolVar(&noDistributed, "no-distributed", false, "Don't dump Distributed tables")
 	dumpSchemaCmd.Flags().BoolVar(&onlyKafkas, "only-kafkas", false, "Dump only Kafka tables")
 	dumpSchemaCmd.Flags().BoolVar(&onlyMatViews, "only-mat-views", false, "Dump only materialized views")
 	dumpSchemaCmd.Flags().BoolVar(&ifNotExists, "if-not-exists", false, "Add IF NOT EXISTS to CREATE TABLE statements")

--- a/schemas.go
+++ b/schemas.go
@@ -17,6 +17,7 @@ type Options struct {
 	TableNamesOnly bool
 	NoKafkas       bool
 	NoMatViews     bool
+	NoDistributed  bool
 	OnlyKafkas     bool
 	OnlyMatViews   bool
 	Apply          bool
@@ -97,6 +98,10 @@ func Write(opts *Options) error {
 
 	if opts.NoMatViews {
 		tableEngines = removeElement(tableEngines, "MaterializedView")
+	}
+
+	if opts.NoDistributed {
+		tableEngines = removeElement(tableEngines, "Distributed")
 	}
 
 	if opts.OnlyKafkas && opts.OnlyMatViews {


### PR DESCRIPTION
## Summary

Adds `--no-distributed` flag to `synch dump-schema`

## Why

When importing a schema into a newly bootstrapped system whose `remote_servers` config
isn't live yet, Distributed CREATE TABLE statements fail at parse-time.