### PR TITLE
feat: Allow for dumping with password secrets left intact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -40,8 +40,8 @@ jobs:
           - { goos: linux,  goarch: arm64 }
           - { goos: darwin, goarch: arm64 }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -54,7 +54,7 @@ jobs:
           mkdir -p dist
           go build -o "dist/synch-${GOOS}-${GOARCH}" .
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: synch-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/*
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Resolve version
@@ -73,11 +73,11 @@ jobs:
           git fetch origin main --depth=1
           echo "version=$(git rev-parse --short origin/main)" >> "$GITHUB_OUTPUT"
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
       - name: Publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: synch ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - '.env.sample'
+      - 'LICENSE'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run tests
+        run: go test ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      matrix:
+        include:
+          - { goos: linux,  goarch: amd64 }
+          - { goos: linux,  goarch: arm64 }
+          - { goos: darwin, goarch: arm64 }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build synch
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist
+          go build -o "dist/synch-${GOOS}-${GOARCH}" .
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: synch-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Resolve version
+        id: version
+        run: |
+          git fetch origin main --depth=1
+          echo "version=$(git rev-parse --short origin/main)" >> "$GITHUB_OUTPUT"
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: synch ${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          files: dist/**/synch-*

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Here's a quick rundown of the commands available:
 # Dump database schema to file _with_ IF NOT EXISTS in CREATE TABLE statements
 ./synch dump-schema --if-not-exists <clickhouse_url> <file> <database>
 
+# Dump database schema to file _with_ secret values intact
+# This is intended for very specific situations and should always be used with care
+# Do NOT use this if you are not sure, and do NOT leave the resulting dump file behind when you are done!
+./synch dump-schema --show-secrets <clickhouse_url> <file> <database>
+
 # <clickhouse_url> here looks like `"clickhouse://user:password@host:port"`
 
 # Synchronize a table across clusters

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 		onlyKafkas    = false
 		onlyMatViews  = false
 		ifNotExists   = false
+		showSecrets   = false
 	)
 
 	dumpSchemaCmd := &cobra.Command{
@@ -114,6 +115,7 @@ func main() {
 				OnlyKafkas:    onlyKafkas,
 				OnlyMatViews:  onlyMatViews,
 				IfNotExists:   ifNotExists,
+				ShowSecrets:   showSecrets,
 			}
 
 			err = Write(&opts)
@@ -134,6 +136,10 @@ func main() {
 	dumpSchemaCmd.Flags().BoolVar(&onlyKafkas, "only-kafkas", false, "Dump only Kafka tables")
 	dumpSchemaCmd.Flags().BoolVar(&onlyMatViews, "only-mat-views", false, "Dump only materialized views")
 	dumpSchemaCmd.Flags().BoolVar(&ifNotExists, "if-not-exists", false, "Add IF NOT EXISTS to CREATE TABLE statements")
+	dumpSchemaCmd.Flags().BoolVar(&showSecrets, "show-secrets", false,
+		"Include secrets (e.g. passwords) in the dumped schema instead of '[HIDDEN]'.\n"+
+			"The connecting user must have the displaySecretsInShowAndSelect privilege.\n"+
+			"Do NOT leave any files in place when you are done, secrets will be exposed in the resulting dump!")
 	cmd.AddCommand(dumpSchemaCmd)
 
 	var (

--- a/schemas.go
+++ b/schemas.go
@@ -22,6 +22,7 @@ type Options struct {
 	OnlyMatViews   bool
 	Apply          bool
 	IfNotExists    bool
+	ShowSecrets    bool
 }
 
 var (
@@ -92,6 +93,17 @@ func Compare(opts *Options) error {
 func Write(opts *Options) error {
 	var fd *os.File
 	var err error
+
+	if opts.ShowSecrets {
+		// Pin the pool to a single connection so the SET below applies to every
+		// subsequent SHOW CREATE query. Requires the connecting user to hold the
+		// displaySecretsInShowAndSelect privilege.
+		opts.DB.SetMaxOpenConns(1)
+		if _, err := opts.DB.Exec("SET format_display_secrets_in_show_and_select = 1"); err != nil {
+			return fmt.Errorf("enabling secret display: %v", err)
+		}
+	}
+
 	if opts.NoKafkas {
 		tableEngines = removeElement(tableEngines, "Kafka")
 	}
@@ -231,7 +243,7 @@ func getTablesByEngine(db *sql.DB, dbName string, engineFilter string) ([]string
 		}
 	}
 
-	if err =rows.Err(); err != nil {
+	if err = rows.Err(); err != nil {
 		return []string{}, fmt.Errorf("getting tables for '%s': %v", dbName, err)
 	}
 


### PR DESCRIPTION
## Summary

This PR introduces a new optional `--show-secrets` flag that will leave passwords in place when a dump is performed. It is intended to help with data migrations between clusters that can result in errors due to the placeholder [HIDDEN] value being mistakenly left or missed.

This should always been used with extreme caution and only when necessary. The default is `false` for the flag and the README reflects this.

Also adds a release workflow to remove the need for manually cutting releases and release notes.

REF: https://github.com/PostHog/clickhouse_team_issues/issues/42

## Changes

- Adds `--show-secrets` flag to `synch dump-schemas`
- Adds automated release workflow
